### PR TITLE
Fix ignoreEnv and rules configurations

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -20,7 +20,7 @@ function formatDocument(document) {
     }
 
     if (getConfig('ignoreEnv')) {
-        opts.env = { PHP_CS_FIXER_IGNORE_ENV: 1 }
+        opts.env = { ...process.env, PHP_CS_FIXER_IGNORE_ENV: 1 }
     }
 
     if (getFixerFromComposer()) {

--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,7 @@ function formatDocument(document) {
 
     let opts = {
         cwd: path.dirname(filename),
-        shell: true,
+        shell: false,
     }
 
     if (getConfig('ignoreEnv')) {
@@ -74,7 +74,7 @@ function formatDocument(document) {
     } else {
         let rules = getConfig('rules')
         if (rules) {
-            args.push(`--rules='${rules}'`)
+            args.push(`--rules=${rules}`)
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "php-cs-fixer",
-    "version": "1.0.1",
+    "version": "1.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "php-cs-fixer",
-            "version": "1.0.1",
+            "version": "1.0.10",
             "hasInstallScript": true,
             "dependencies": {
                 "tmp": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "PHP CS Fixer",
     "description": "PHP CS Fixer extension for VS Code with zero config",
     "icon": "icon.png",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "publisher": "mansoorkhan96",
     "engines": {
         "vscode": "^1.18.0"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
                     "default": "",
                     "description": "The path to the php-cs-fixer tool"
                 },
+                "php-cs-fixer.ignoreEnv": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Ignore php-cs-fixer tool environment requirements"
+                },
                 "php-cs-fixer.phpCmd": {
                     "type": "string",
                     "default": "",


### PR DESCRIPTION
Fix to the missing vscode `ignoreEnv` option.
Fix to an issue with the `rules` configuration option ([child_process.execFile](https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback) strips away double quotes on JSON string).